### PR TITLE
Improve travis-ci test and deploy phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ atlassian-ide-plugin.xml
 # Maven
 /.repostory/
 
+# Visual Studio Code
+/.vscode/
 
 # PD Build Tools #
 ##################

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,38 @@
 language: java
 jdk:
   - oraclejdk8
-install:
-  - mvn --settings .travis/settings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
+  - openjdk8
+  - openjdk11
+matrix:
+  allow_failures:
+    - jdk: openjdk11
+install: true
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
-deploy:
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: rapid7/docker-image-analyzer
-      branch: master
+script:
+  - mvn test -Dgpg.skip -Dmaven.javadoc.skip=true -B -V -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+jobs:
+  include:
+    - stage: deploy
+      if: branch =~ /^(?:master|\d+\.\d+(\.\d+)?(-\S*)?)$/ AND type != pull_request AND fork = false
+      script: skip
       jdk: oraclejdk8
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: rapid7/docker-image-analyzer
-      tags: true
-      jdk: oraclejdk8
+      deploy:
+        -
+          provider: script
+          script: .travis/deploy.sh
+          skip_cleanup: true
+          on:
+            repo: rapid7/docker-image-analyzer
+            branch: master
+        -
+          provider: script
+          script: .travis/deploy.sh
+          skip_cleanup: true
+          on:
+            repo: rapid7/docker-image-analyzer
+            tags: true
+cache:
+  directories:
+    - $HOME/.m2

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -6,4 +6,4 @@ else
     echo "not on a tag -> keep snapshot version in pom.xml"
 fi
 
-mvn clean deploy --settings .travis/settings.xml -DskipTests=true -B -U
+mvn clean deploy --settings .travis/settings.xml -DskipTests=true -Dmaven.antrun.skip=true -Prelease -B -V -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## Docker Image Analyzer
 
+
+[![Travis (.org)](https://img.shields.io/travis/rapid7/docker-image-analyzer.svg)](https://travis-ci.org/rapid7/docker-image-analyzer) [![Maven Central](https://img.shields.io/maven-central/v/com.rapid7.docker/docker-image-analyzer.svg)](https://search.maven.org/artifact/com.rapid7.docker/docker-image-analyzer)
+
 Extracts, parses, and analyzes [Docker](https://www.docker.com) images into Java objects with JSON mappings.
 
 ## Getting Started

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   </scm>
 
   <properties>
-    <r7.recog.java.version>1.0.5</r7.recog.java.version>
+    <r7.recog.java.version>0.7.0</r7.recog.java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,7 +26,7 @@
   <dependencies>
     <!-- Rapid7 dependencies -->
     <dependency>
-      <groupId>org.rapid7.recog</groupId>
+      <groupId>com.rapid7.recog</groupId>
       <artifactId>recog-java</artifactId>
       <version>${r7.recog.java.version}</version>
     </dependency>
@@ -155,62 +155,6 @@
         </dependencies>
       </plugin>
 
-      <!-- TODO: uncomment when using travis-ci to publish to maven central
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -222,6 +166,7 @@
         <executions>
           <execution>
             <id>checkstyle</id>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>
@@ -241,4 +186,73 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.3</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Description
- Add OpenJDK 8 and 11 runtimes
- Make sure checkstyle runs during test phase
- Move deploy into a stage so it only runs once after tests pass
- Reduce log noise from maven downloads
- Cache maven repo
- Add badges to readme
- Add a release maven profile


## Motivation and Context
I wanted to make sure that all tests are running appropriately and that deploys don't get cluttered in test runs.


## How Has This Been Tested?
This pull request will be tested!