### PR TITLE
Enable fingerprinting of jars located in m2 repositories

### DIFF
--- a/src/main/java/com/rapid7/container/analyzer/docker/fingerprinter/JavaM2RepositoryFingerprinter.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/fingerprinter/JavaM2RepositoryFingerprinter.java
@@ -5,7 +5,6 @@ import com.rapid7.container.analyzer.docker.model.LayerPath;
 import com.rapid7.container.analyzer.docker.model.image.Image;
 import com.rapid7.container.analyzer.docker.model.json.Configuration;
 import com.rapid7.container.analyzer.docker.packages.M2RepositoryParser;
-import com.rapid7.container.analyzer.docker.packages.OwaspDependencyParser;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,7 +15,7 @@ public class JavaM2RepositoryFingerprinter implements LayerFileHandler {
 
   private final M2RepositoryParser m2RepositoryParser;
 
-  public JavaM2RepositoryFingerprinter(M2RepositoryParser m2RepositoryParser){
+  public JavaM2RepositoryFingerprinter(M2RepositoryParser m2RepositoryParser) {
     this.m2RepositoryParser = m2RepositoryParser;
   }
 

--- a/src/main/java/com/rapid7/container/analyzer/docker/fingerprinter/JavaM2RepositoryFingerprinter.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/fingerprinter/JavaM2RepositoryFingerprinter.java
@@ -1,0 +1,33 @@
+package com.rapid7.container.analyzer.docker.fingerprinter;
+
+import com.rapid7.container.analyzer.docker.analyzer.LayerFileHandler;
+import com.rapid7.container.analyzer.docker.model.LayerPath;
+import com.rapid7.container.analyzer.docker.model.image.Image;
+import com.rapid7.container.analyzer.docker.model.json.Configuration;
+import com.rapid7.container.analyzer.docker.packages.M2RepositoryParser;
+import com.rapid7.container.analyzer.docker.packages.OwaspDependencyParser;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+
+public class JavaM2RepositoryFingerprinter implements LayerFileHandler {
+
+  private final M2RepositoryParser m2RepositoryParser;
+
+  public JavaM2RepositoryFingerprinter(M2RepositoryParser m2RepositoryParser){
+    this.m2RepositoryParser = m2RepositoryParser;
+  }
+
+  @Override
+  public void handle(String name, TarArchiveEntry entry, InputStream contents, Image image, Configuration configuration, LayerPath layerPath) throws IOException {
+    if (m2RepositoryParser.supports(name, entry)) {
+      File tmpFile = Paths.get(layerPath.getPath(), name).toFile();
+      if (tmpFile.isFile()) {
+        layerPath.getLayer().addPackages(m2RepositoryParser.parse(tmpFile, image.getOperatingSystem() == null
+            ? layerPath.getLayer().getOperatingSystem() : image.getOperatingSystem()));
+      }
+    }
+  }
+}

--- a/src/main/java/com/rapid7/container/analyzer/docker/packages/M2RepositoryParser.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/packages/M2RepositoryParser.java
@@ -1,0 +1,61 @@
+package com.rapid7.container.analyzer.docker.packages;
+
+import com.rapid7.container.analyzer.docker.model.image.OperatingSystem;
+import com.rapid7.container.analyzer.docker.model.image.Package;
+import com.rapid7.container.analyzer.docker.model.image.PackageType;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
+public class M2RepositoryParser implements PackageParser<File> {
+
+  private static final String M2_REPOSITORY_SUBSTRING = ".m2/repository/";
+  private static final Pattern M2_REPOSITORY_PATTERN = Pattern.compile(".*(?i)(\\.(m2/repository)).*(.jar|.pom)$");
+  private static final String GROUP_ID_DELIMITER = ".";
+  private static final String PACKAGE_NAME_FORMAT = "%s:%s";
+
+  @Override
+  public boolean supports(String name, TarArchiveEntry entry) {
+    return !entry.isSymbolicLink() && M2_REPOSITORY_PATTERN.matcher(name).matches();
+  }
+
+  @Override
+  public Set<Package> parse(File input, OperatingSystem operatingSystem) throws IOException {
+    String relativePath = input.getPath().toLowerCase().substring(input.getPath().toLowerCase().indexOf(M2_REPOSITORY_SUBSTRING) + M2_REPOSITORY_SUBSTRING.length());
+    String[] pathParts = relativePath.split("/");
+    if (pathParts.length < 4) {
+      return emptySet();
+    }
+    String fileName = pathParts[pathParts.length - 1];
+    String versionNumber = pathParts[pathParts.length - 2];
+    String artifactId = pathParts[pathParts.length - 3];
+    String groupId = extractGroupId(pathParts);
+
+    return singleton(new Package(
+        fileName,
+        PackageType.JAVA,
+        null,
+        format(PACKAGE_NAME_FORMAT, groupId, artifactId),
+        versionNumber,
+        null,
+        0L,
+        null,
+        null,
+        null));
+  }
+
+  private String extractGroupId(String[] pathParts) {
+    ArrayDeque<String> groupIdParts = new ArrayDeque<>();
+    for (int i = pathParts.length - 4; i >= 0; --i) {
+      groupIdParts.push(pathParts[i]);
+    }
+    return join(GROUP_ID_DELIMITER, groupIdParts);
+  }
+}

--- a/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
@@ -11,6 +11,7 @@ import com.rapid7.container.analyzer.docker.fingerprinter.ApkgFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.DotNetFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.DpkgFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.FileFingerprinter;
+import com.rapid7.container.analyzer.docker.fingerprinter.JavaM2RepositoryFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.OsReleaseFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.OwaspDependencyFingerprinter;
 import com.rapid7.container.analyzer.docker.fingerprinter.PacmanFingerprinter;
@@ -34,6 +35,7 @@ import com.rapid7.container.analyzer.docker.os.Fingerprinter;
 import com.rapid7.container.analyzer.docker.packages.ApkgParser;
 import com.rapid7.container.analyzer.docker.packages.DotNetParser;
 import com.rapid7.container.analyzer.docker.packages.DpkgParser;
+import com.rapid7.container.analyzer.docker.packages.M2RepositoryParser;
 import com.rapid7.container.analyzer.docker.packages.OwaspDependencyParser;
 import com.rapid7.container.analyzer.docker.packages.PacmanPackageParser;
 import com.rapid7.container.analyzer.docker.packages.RpmPackageParser;
@@ -106,6 +108,7 @@ public class DockerImageAnalyzerService {
     layerHandlers.add(new ApkgFingerprinter(new ApkgParser()));
     layerHandlers.add(new PacmanFingerprinter(new PacmanPackageParser()));
     layerHandlers.add(new OwaspDependencyFingerprinter(new OwaspDependencyParser(owaspBuilder)));
+    layerHandlers.add(new JavaM2RepositoryFingerprinter(new M2RepositoryParser()));
     layerHandlers.addAll(customBuilder.getFingerprinters());
   }
 

--- a/src/test/java/com/rapid7/container/analyzer/docker/packages/M2RepositoryParserTest.java
+++ b/src/test/java/com/rapid7/container/analyzer/docker/packages/M2RepositoryParserTest.java
@@ -1,0 +1,161 @@
+package com.rapid7.container.analyzer.docker.packages;
+
+import com.rapid7.container.analyzer.docker.model.image.OperatingSystem;
+import com.rapid7.container.analyzer.docker.model.image.Package;
+import com.rapid7.container.analyzer.docker.packages.settings.OwaspDependencyParserSettingsBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+
+public class M2RepositoryParserTest {
+
+  private M2RepositoryParser m2RepositoryParser;
+  @Mock
+  private TarArchiveEntry tarArchiveEntry;
+
+  @BeforeEach
+  public void setup() {
+    m2RepositoryParser = new M2RepositoryParser();
+  }
+
+  @Test
+  public void hasExpectedGroupIdWhenGroupIdIsOnePart() throws IOException {
+    String expectedGroupId = "groupid";
+    String path = "/.m2/repository/" + expectedGroupId + "/artifactId/1.0.0/artifactId-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(expectedGroupId, packages.iterator().next().getPackage().split(":")[0]);
+  }
+
+  @Test
+  public void hasExpectedGroupIdWhenGroupIdIsMultipleParts() throws IOException {
+    String expectedGroupId = "a/delimited/groupid/for/a/package";
+    String path = "prefix/prefix/prefix/.m2/repository/" + expectedGroupId + "/artifactId/1.0.0/artifactId-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(expectedGroupId.replaceAll("/", "."), packages.iterator().next().getPackage().split(":")[0]);
+  }
+
+  @Test
+  public void hasExpectedArtifactId() throws IOException {
+    String expectedArtifactId = "artifactid";
+    String path = "/.m2/repository/groupId/" + expectedArtifactId + "/1.0.0/artifactId-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(expectedArtifactId, packages.iterator().next().getPackage().split(":")[1]);
+  }
+
+  @Test
+  public void hasExpectedPackageName() throws IOException {
+    String expectedGroupId = "groupid";
+    String expectedArtifactId = "artifactid";
+    String path = "/.m2/repository/" + expectedGroupId + "/" + expectedArtifactId + "/1.0.0/artifactId-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(format("%s:%s", expectedGroupId, expectedArtifactId), packages.iterator().next().getPackage());
+  }
+
+  @Test
+  public void hasExpectedVersion() throws IOException {
+    String expectedVersion = "1.0.0";
+    String path = "/.m2/repository/groupId/artifactId/" + expectedVersion + "/artifactId-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(expectedVersion, packages.iterator().next().getVersion());
+  }
+
+  @Test
+  public void hasExpectedSource() throws IOException {
+    String expectedSource = "artifactid-1.0.0.jar";
+    String path = "/.m2/repository/groupId/artifactId/1.0.0/" + expectedSource;
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+
+    assertEquals(1, packages.size());
+    assertEquals(expectedSource, packages.iterator().next().getSource());
+  }
+
+  @Test
+  public void returnsEmptySetIfNotEnoughPartsInPath() throws IOException {
+    String path = "/.m2/repository/groupId/artifactId/someJar-1.0.0.jar";
+    File jarFile = Mockito.mock(File.class);
+    when(jarFile.getPath()).thenReturn(path);
+
+    Set<Package> packages = m2RepositoryParser.parse(jarFile, null);
+    assertEquals(0, packages.size());
+  }
+
+  @Test
+  public void doesNotSupportSymbolicEntries() {
+    when(tarArchiveEntry.isSymbolicLink()).thenReturn(true);
+    String fileName = "app.jar";
+    assertFalse(m2RepositoryParser.supports(fileName, tarArchiveEntry));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/.m2/repository/groupId/artifactId/versionNumber/app-versionNumber.jar", "var/file/bam/.m2/repository/groupId/groupId2/artifactId/versionNumber/app.jar"})
+  public void supportsJarFiles(String fileName) {
+    when(tarArchiveEntry.isSymbolicLink()).thenReturn(false);
+    assertTrue(m2RepositoryParser.supports(fileName, tarArchiveEntry));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/.m2/repository/groupId/artifactId/versionNumber/app-versionNumber.pom", "var/file/bam/.m2/repository/groupId/groupId2/artifactId/versionNumber/app.pom"})
+  public void supportsPomFiles(String fileName) {
+    when(tarArchiveEntry.isSymbolicLink()).thenReturn(false);
+    assertTrue(m2RepositoryParser.supports(fileName, tarArchiveEntry));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/m2/repository/groupId/artifactId/versionNumber/app-versionNumber.pom", "var/file/bam/repository/groupId/groupId2/artifactId/versionNumber/app.pom", "groupId/groupId2/artifactId/versionNumber/app.pom"})
+  public void doesNotSupportNonM2Repositories(String fileName) {
+    when(tarArchiveEntry.isSymbolicLink()).thenReturn(false);
+    assertFalse(m2RepositoryParser.supports(fileName, tarArchiveEntry));
+  }
+
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/.m2/repository/groupId/artifactId/versionNumber/app-versionNumber.JAR", "var/file/bam/.m2/repository/groupId/groupId2/artifactId/versionNumber/app.JAR"})
+  public void isCaseInsensitiveForExtensions(String fileName) {
+    when(tarArchiveEntry.isSymbolicLink()).thenReturn(false);
+    assertTrue(m2RepositoryParser.supports(fileName, tarArchiveEntry));
+  }
+}


### PR DESCRIPTION
## Description
A detailed description of your changes.

This change adds a new fingerprinter capable of finding jar files in .m2 repositories, which may be present in the root directory of certain docker containers.

## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.

To increase coverage for finding Java dependencies

## How Has This Been Tested?
A clear and concise description of your changes were tested.
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
