### PR TITLE
SI-16392

### DIFF
--- a/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
@@ -175,12 +175,24 @@ public class DockerImageAnalyzerService {
     try {
       // parse the image configuration
       List<HistoryJson> layerHistories = configuration.getHistory();
+      if (layerHistories == null) {
+        LOGGER.error("Layer histories either do not exist or there was an error parsing them. Image with id " + id.getId() + " has been SKIPPED.");
+        return null;
+      }
 
       // the ordered identifiers of non-empty layers (which are presumed to have file-system changes requiring a blob)
       List<LayerId> layers = manifest.getLayers();
+      if (layers == null) {
+        LOGGER.error("There was an error parsing layers. Image with id " + id.getId() + " has been SKIPPED.");
+        return null;
+      }
 
       // the ordered identifiers of the blobs to retrieve for each non-empty layer
       List<LayerId> layerBlobIds = manifest.getLayerBlobIds();
+      if (layerBlobIds == null) {
+        LOGGER.error("There was an error parsing layer blog ids. Image with id " + id.getId() + " has been SKIPPED.");
+        return null;
+      }
 
       // TODO: not pulling out the repository in the digest reference
       Image image = new Image(id, ImageType.DOCKER, digest, manifest.getSize(), configuration.getCreated());

--- a/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/service/DockerImageAnalyzerService.java
@@ -176,7 +176,7 @@ public class DockerImageAnalyzerService {
       // parse the image configuration
       List<HistoryJson> layerHistories = configuration.getHistory();
       if (layerHistories == null) {
-        LOGGER.error("Layer histories either do not exist or there was an error parsing them. Image with id " + id.getId() + " has been SKIPPED.");
+        LOGGER.error("Layer histories either do not exist or there was an error parsing them. Image with id {} has been SKIPPED.", id.getId());
         return null;
       }
 


### PR DESCRIPTION
## Description
Added null checks for objects parsed out of the config file.


## Motivation and Context
SI-16392 When an improper image was encountered on a registry the entire application would exit, rather than skipping that image and continuing to sync the other images. 


## How Has This Been Tested?
ran a mvn clean install.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
