### PR TITLE
Log error when parsing os packages without knowing all the os fields

### DIFF
--- a/src/main/java/com/rapid7/container/analyzer/docker/packages/PatternPackageParser.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/packages/PatternPackageParser.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
+import static jdk.internal.joptsimple.internal.Strings.isNullOrEmpty;
 
 public abstract class PatternPackageParser implements PackageParser<InputStream> {
 
@@ -36,9 +37,20 @@ public abstract class PatternPackageParser implements PackageParser<InputStream>
 
   public abstract boolean supports(String name, TarArchiveEntry entry);
 
+  private static boolean doesOperatingSystemHaveAllNecessaryFields(OperatingSystem os) {
+    if (os == null || isNullOrEmpty(os.getName()) || isNullOrEmpty(os.getFamily()) ||  isNullOrEmpty(os.getVendor()) || isNullOrEmpty(os.getVersion())) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   public Set<Package> parse(InputStream input, OperatingSystem operatingSystem) throws FileNotFoundException, IOException {
 
     LOGGER.info("Parsing packages using {} with operating system {}.", getClass().getSimpleName(), operatingSystem);
+    if (!doesOperatingSystemHaveAllNecessaryFields(operatingSystem)) {
+      LOGGER.error("Parsing os packages using {} but operating system does not have all the necessary fields: {}", getClass().getSimpleName(), operatingSystem.toString());
+    }
 
     Set<Package> packages = new HashSet<>();
     try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {

--- a/src/main/java/com/rapid7/container/analyzer/docker/packages/PatternPackageParser.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/packages/PatternPackageParser.java
@@ -17,9 +17,9 @@ import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
-import static jdk.internal.joptsimple.internal.Strings.isNullOrEmpty;
 
 public abstract class PatternPackageParser implements PackageParser<InputStream> {
 
@@ -49,7 +49,7 @@ public abstract class PatternPackageParser implements PackageParser<InputStream>
 
     LOGGER.info("Parsing packages using {} with operating system {}.", getClass().getSimpleName(), operatingSystem);
     if (!doesOperatingSystemHaveAllNecessaryFields(operatingSystem)) {
-      LOGGER.error("Parsing os packages using {} but operating system does not have all the necessary fields: {}", getClass().getSimpleName(), operatingSystem.toString());
+      LOGGER.error("Parsing os packages using {} but operating system does not have all the necessary fields. OS is {}.", getClass().getSimpleName(), operatingSystem);
     }
 
     Set<Package> packages = new HashSet<>();


### PR DESCRIPTION
## Description
Log error when parsing os packages without knowing all the os fields


## Motivation and Context
Need to find out when and why os packages are being saved without knowing all the os info

## How Has This Been Tested?
It's a log statement so no testing has been done


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
addition log statement


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
