### PR TITLE
Add manual workflow trigger and use Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     name: 'Java: ${{ matrix.java }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
## Description
Add manual workflow trigger so we can run tests on-demand.

Also switch back to Ubuntu 20.04 runner because 22.04 causes test failures (todo: investigate)

## Motivation and Context
I want to be able to run tests outside the context of changes to see if environment changes results over time.


## How Has This Been Tested?
Manual execution has not been tested because it needs to be merged first.

Ubuntu change tested in this PR's checks.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Github test environment setup only


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] All new and existing tests passed.
