### PR TITLE
Disable dotnet owasp analyzer

### DIFF
--- a/src/main/java/com/rapid7/container/analyzer/docker/packages/settings/OwaspDependencyParserSettingsBuilder.java
+++ b/src/main/java/com/rapid7/container/analyzer/docker/packages/settings/OwaspDependencyParserSettingsBuilder.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.owasp.dependencycheck.analyzer.AbstractAnalyzer;
 import org.owasp.dependencycheck.analyzer.ArchiveAnalyzer;
 import org.owasp.dependencycheck.analyzer.AssemblyAnalyzer;
@@ -40,16 +41,20 @@ import static java.util.Arrays.asList;
 public class OwaspDependencyParserSettingsBuilder {
 
   public static OwaspDependencyParserSettingsBuilder ALL = OwaspDependencyParserSettingsBuilder.builder()
-      .enableAnalyzers(Analyzer.values())
+      .enableAnalyzers(Arrays.stream(Analyzer.values())
+        .filter(analyzer -> analyzer != Analyzer.ASSEMBLY)
+        .toArray(Analyzer[]::new))
       .allowExperimentalAnalyzers()
       .allowRetiredAnalyzers();
   public static OwaspDependencyParserSettingsBuilder EXPERIMENTAL = OwaspDependencyParserSettingsBuilder.builder()
       .enableAnalyzers(Arrays.stream(Analyzer.values())
+          .filter(analyzer -> analyzer != Analyzer.ASSEMBLY)
           .filter(analyzer -> !analyzer.isRetired())
           .toArray(Analyzer[]::new))
       .allowExperimentalAnalyzers();
   public static OwaspDependencyParserSettingsBuilder DEFAULT = OwaspDependencyParserSettingsBuilder.builder()
       .enableAnalyzers(Arrays.stream(Analyzer.values())
+          .filter(analyzer -> analyzer != Analyzer.ASSEMBLY)
           .filter(analyzer -> !analyzer.isRetired())
           .filter(analyzer -> !analyzer.isExperimental())
           .toArray(Analyzer[]::new));

--- a/src/test/java/com/rapid7/container/analyzer/docker/packages/settings/OwaspDependencyParserSettingsBuilderTest.java
+++ b/src/test/java/com/rapid7/container/analyzer/docker/packages/settings/OwaspDependencyParserSettingsBuilderTest.java
@@ -30,8 +30,12 @@ public class OwaspDependencyParserSettingsBuilderTest {
         .map(OwaspDependencyParserSettingsBuilder.Analyzer::getToggleKey)
         .collect(toList());
     for (String analyzerToggleKey : analyzerToggleKeys) {
-      assertTrue(settings.getBoolean(analyzerToggleKey),
+      if (analyzerToggleKey.equals("analyzer.assembly.enabled")) {
+        assertFalse(settings.getBoolean(analyzerToggleKey), "Expected setting " + analyzerToggleKey + " to be false");
+      } else {
+        assertTrue(settings.getBoolean(analyzerToggleKey),
           "Expected setting " + analyzerToggleKey + " to be true");
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Disable the dotnet assembly checker from owasp because the container-registry-sync-app image doesn't have the necessary packages to run it. 


## Motivation and Context
Explanation of why these changes are being proposed, including any links to other relevant issues or pull requests.


## How Has This Been Tested?
A clear and concise description of your changes were tested.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
